### PR TITLE
Added autocomplete options hook

### DIFF
--- a/cmb2-field-ajax-search.php
+++ b/cmb2-field-ajax-search.php
@@ -188,7 +188,8 @@ if( ! class_exists( 'CMB2_Field_Ajax_Search' ) ) {
 
 			wp_localize_script( 'cmb-ajax-search', 'cmb_ajax_search', array(
 				'ajaxurl' 	=> admin_url( 'admin-ajax.php' ),
-				'nonce'		=> wp_create_nonce( 'cmb_ajax_search_get_results' )
+				'nonce'		=> wp_create_nonce( 'cmb_ajax_search_get_results' ),
+				'options' 	=> apply_filters( 'cmb_field_ajax_search_autocomplete_options', array() )
 			) );
 
 			wp_enqueue_script( 'cmb-ajax-search' );

--- a/js/ajax-search.js
+++ b/js/ajax-search.js
@@ -8,7 +8,7 @@
 			var object_type = $(this).attr('data-object-type');
 			var query_args 	= $(this).attr('data-query-args');
 
-			$(this).devbridgeAutocomplete({
+			$(this).devbridgeAutocomplete(Object.assign({
 				serviceUrl: cmb_ajax_search.ajaxurl,
 				type: 'POST',
 				triggerSelectOnValidInput: false,
@@ -78,7 +78,8 @@
 						$('input[name=' + field_name + ']').val( suggestion.id ).change();
 					}
 				}
-			});
+			},
+			cmb_ajax_search.options));
 
 			if( $(this).attr('data-sortable') == 1 ){
 				$('#' + field_id + '_results').sortable({


### PR DESCRIPTION
@rubengc 
I want to set jQuery-Autocomplete options.
So I added a filter hook that can set options.

For example, as follows.
```
add_filter( 'cmb_field_ajax_search_autocomplete_options', function ( $options ) {
	$options = [
		'minChars' => 3,
	];

	return $options;
} );
```